### PR TITLE
Notes screen showing empty state as first state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
-        android:allowBackup="true"
         android:name=".activity.LifeHubApplication"
+        android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
@@ -16,7 +16,8 @@
         <activity
             android:name=".activity.MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.LifeHub">
+            android:theme="@style/Theme.LifeHub"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/lifehub/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/lifehub/navigation/NavGraph.kt
@@ -60,7 +60,7 @@ fun NavGraph(
         }
 
         composable(Destinations.NOTE_DETAILS_ROUTE) {
-            NoteDetailsScreen(resultViewModel = resultViewModel,
+            NoteDetailsScreen(
                 onClickBack = { navController.navigateUp() },
                 onDeleteNote = {
                     resultViewModel.postSnackBarMessage(R.string.successfully_deleted_note_message)

--- a/app/src/main/java/com/example/lifehub/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/lifehub/navigation/NavGraph.kt
@@ -56,7 +56,10 @@ fun NavGraph(
         }
 
         composable(Destinations.ADD_NOTE_ROUTE) {
-            AddNoteScreen(onClickBack = { navController.popBackStack() })
+            AddNoteScreen(onAddNote = {
+                resultViewModel.postSnackBarMessage(R.string.successfully_created_note_message)
+                navController.popBackStack()
+            }, onClickBack = { navController.popBackStack() })
         }
 
         composable(Destinations.NOTE_DETAILS_ROUTE) {

--- a/app/src/main/java/com/example/lifehub/theme/color/Color.kt
+++ b/app/src/main/java/com/example/lifehub/theme/color/Color.kt
@@ -8,7 +8,7 @@ val onPrimaryLight = Color(0xFFFFFFFF)
 val secondaryLight = Color(0xFF1D4F91)  // Dark blue for accents (tertiary)
 val onSecondaryLight = Color(0xFFFFFFFF)
 
-val backgroundLight = Color(0xFFF3F4F6)  // Light gray background
+val backgroundLight = Color(0xFFFFFFFF)  // White background
 val onBackgroundLight = Color(0xFF000000)  // Black text for contrast
 
 val surfaceLight = Color(0xFFFFFFFF)  // White for cards/surfaces

--- a/app/src/main/java/com/example/lifehub/theme/color/ColorScheme.kt
+++ b/app/src/main/java/com/example/lifehub/theme/color/ColorScheme.kt
@@ -29,6 +29,7 @@ val lightColorScheme = lightColorScheme(
     surfaceContainerHighest = surfaceLight,
     primaryContainer = primaryLight,
     outline = outlineLight,
+    surfaceContainer = backgroundLight,
     error = errorLight,
     onError = onErrorLight
 )

--- a/app/src/main/java/com/example/lifehub/ui/components/Inputs.kt
+++ b/app/src/main/java/com/example/lifehub/ui/components/Inputs.kt
@@ -89,8 +89,8 @@ fun TextInput(
                 focusedTextColor = MaterialTheme.colorScheme.onSurface,
                 cursorColor = MaterialTheme.colorScheme.secondary,
                 focusedBorderColor = MaterialTheme.colorScheme.secondary,
-                unfocusedContainerColor = Color(0XFFE1F5FE),
-                focusedContainerColor = Color(0XFFE1F5FE)
+                unfocusedContainerColor = Color(0xFFEBF9FF),
+                focusedContainerColor = Color(0xFFEBF9FF)
             )
         )
     }

--- a/app/src/main/java/com/example/lifehub/ui/components/UiStateScreenContainer.kt
+++ b/app/src/main/java/com/example/lifehub/ui/components/UiStateScreenContainer.kt
@@ -1,10 +1,14 @@
 package com.example.lifehub.ui.components
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -28,25 +32,47 @@ fun UiStateScreenContainer(
     loading: Boolean,
     empty: Boolean,
     emptyContent: @Composable () -> Unit,
-    onRefresh: () -> Unit,
     modifier: Modifier = Modifier,
+    onRefresh: (() -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
-    val pullRefreshState = rememberPullToRefreshState()
-
-    PullToRefreshBox(
-        state = pullRefreshState,
-        modifier = modifier,
-        isRefreshing = loading,
-        onRefresh = onRefresh
-    ) {
-        if (empty) {
-            emptyContent()
-        } else {
-            content()
+    if (onRefresh != null) {
+        val pullRefreshState = rememberPullToRefreshState()
+        PullToRefreshBox(
+            state = pullRefreshState,
+            modifier = modifier,
+            isRefreshing = loading,
+            onRefresh = onRefresh
+        ) {
+            ScreenContent(loading, empty, emptyContent, content)
+        }
+    } else {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            ScreenContent(loading, empty, emptyContent, content)
         }
     }
 }
+
+/**
+ * A helper composable that handles loading, empty, and valid content states.
+ */
+@Composable
+private fun ScreenContent(
+    loading: Boolean,
+    empty: Boolean,
+    emptyContent: @Composable () -> Unit,
+    content: @Composable () -> Unit
+) {
+    when {
+        loading -> CircularProgressIndicator()
+        empty -> emptyContent()
+        else -> content()
+    }
+}
+
 
 @Preview(showBackground = true, backgroundColor = 0xD1D5DB)
 @Composable

--- a/app/src/main/java/com/example/lifehub/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/lifehub/ui/screens/home/HomeScreen.kt
@@ -6,12 +6,15 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -32,8 +35,14 @@ import com.example.lifehub.util.DynamicImage
 
 @Composable
 fun HomeScreen(onClickCategory: () -> Unit) {
-    Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-        HomeScreenContent(modifier = Modifier.padding(innerPadding), onClickCategory = onClickCategory)
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.only(WindowInsetsSides.Top),
+    ) { innerPadding ->
+        HomeScreenContent(
+            modifier = Modifier.padding(innerPadding),
+            onClickCategory = onClickCategory
+        )
     }
 }
 

--- a/app/src/main/java/com/example/lifehub/ui/screens/notes/NotesScreen.kt
+++ b/app/src/main/java/com/example/lifehub/ui/screens/notes/NotesScreen.kt
@@ -1,10 +1,14 @@
 package com.example.lifehub.ui.screens.notes
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -17,6 +21,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -24,11 +29,15 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -41,6 +50,8 @@ import com.example.lifehub.data.model.Note
 import com.example.lifehub.theme.LifeHubTheme
 import com.example.lifehub.ui.components.EmptyState
 import com.example.lifehub.ui.components.UiStateScreenContainer
+import com.example.lifehub.ui.screens.notes.notedetails.DeleteNoteBottomSheet
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -52,20 +63,28 @@ fun NotesScreen(
     onNoteClick: (String) -> Unit,
     onClickBack: () -> Unit
 ) {
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-
-    val message = resultViewModel.snackBarMessage.collectAsState().value
+    val message by resultViewModel.snackBarMessage.collectAsState()
     val snackBarText = message?.let { stringResource(id = it) }
+
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+    val sheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
+    var showBottomSheet by remember { mutableStateOf(false) }
+    var noteId by remember { mutableStateOf("") }
 
     Scaffold(modifier = Modifier
         .fillMaxSize()
         .nestedScroll(scrollBehavior.nestedScrollConnection),
+        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.only(WindowInsetsSides.Top),
         snackbarHost = { SnackbarHost(snackBarHostState) },
         topBar = {
             NoteScreenTopBar(scrollBehavior = scrollBehavior, onClickBack = onClickBack)
         }, floatingActionButton = {
-            SmallFloatingActionButton(onClick = onClickAddNote) {
+            SmallFloatingActionButton(
+                modifier = Modifier.navigationBarsPadding(),
+                onClick = onClickAddNote
+            ) {
                 Icon(
                     imageVector = Icons.Filled.Add,
                     contentDescription = "fab add new note"
@@ -75,16 +94,36 @@ fun NotesScreen(
 
         NotesContent(
             uiState = uiState,
-            modifier = Modifier.padding(paddingValues),
+            modifier = Modifier
+                .padding(paddingValues),
             onNoteClick = onNoteClick,
-            onClickAddNote = onClickAddNote
-        )
+            onClickAddNote = onClickAddNote,
+            onNoteLongClick = { id ->
+                noteId = id
+                showBottomSheet = true
+            })
 
         LaunchedEffect(snackBarText) {
             snackBarText?.let {
                 snackBarHostState.showSnackbar(it)
                 resultViewModel.snackBarMessageShown()
             }
+        }
+
+        if (showBottomSheet) {
+            DeleteNoteBottomSheet(sheetState = sheetState, onDismiss = {
+                showBottomSheet = false
+            }, onConfirmDelete = {
+                scope.launch {
+                    viewModel.deleteNote(noteId = noteId)
+                    resultViewModel.postSnackBarMessage(R.string.successfully_deleted_note_message)
+                    sheetState.hide()
+                }.invokeOnCompletion {
+                    if (!sheetState.isVisible) {
+                        showBottomSheet = false
+                    }
+                }
+            })
         }
     }
 }
@@ -116,7 +155,8 @@ fun NotesContent(
     uiState: NotesUiState,
     modifier: Modifier = Modifier,
     onNoteClick: (String) -> Unit,
-    onClickAddNote: () -> Unit
+    onNoteLongClick: (String) -> Unit,
+    onClickAddNote: () -> Unit,
 ) {
     UiStateScreenContainer(
         loading = uiState.isLoading,
@@ -129,32 +169,36 @@ fun NotesContent(
                 onClick = onClickAddNote
             )
         },
-        onRefresh = {}
+        onRefresh = null
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
+                .navigationBarsPadding()
         ) {
             uiState.items.forEach { note ->
-                NoteItem(note = note, onNoteClick = onNoteClick)
+                NoteItem(note = note, onNoteClick = onNoteClick, onNoteLongClick = onNoteLongClick)
             }
         }
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun NoteItem(
     note: Note,
-    onNoteClick: (String) -> Unit
+    onNoteClick: (String) -> Unit,
+    onNoteLongClick: (String) -> Unit
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable {
-                onNoteClick(note.id)
-            },
-        verticalArrangement = Arrangement.spacedBy(LifeHubTheme.spacing.stack.medium)
+            .combinedClickable(
+                onClick = { onNoteClick(note.id) },
+                onLongClick = { onNoteLongClick(note.id) }
+            ),
+        verticalArrangement = Arrangement.spacedBy(LifeHubTheme.spacing.stack.small)
     ) {
         Column(
             modifier = Modifier.padding(

--- a/app/src/main/java/com/example/lifehub/ui/screens/notes/NotesViewModel.kt
+++ b/app/src/main/java/com/example/lifehub/ui/screens/notes/NotesViewModel.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class NotesUiState(
@@ -18,13 +19,12 @@ data class NotesUiState(
 
 @HiltViewModel
 class NotesViewModel @Inject constructor(
-    repository: NotesRepository
+    private val repository: NotesRepository
 ) : ViewModel() {
-
 
     val uiState: StateFlow<NotesUiState> = repository.getNotesListFlow().map { notes ->
         NotesUiState(
-            items = notes,
+            items = notes.reversed(),
             isLoading = false,
         )
     }.stateIn(
@@ -32,4 +32,8 @@ class NotesViewModel @Inject constructor(
         started = WhileUiSubscribed,
         initialValue = NotesUiState(isLoading = true)
     )
+
+    fun deleteNote(noteId: String) = viewModelScope.launch {
+        repository.deleteNote(noteId = noteId)
+    }
 }

--- a/app/src/main/java/com/example/lifehub/ui/screens/notes/add/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/lifehub/ui/screens/notes/add/AddNoteScreen.kt
@@ -2,23 +2,23 @@ package com.example.lifehub.ui.screens.notes.add
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -30,7 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Preview
@@ -51,23 +51,24 @@ fun AddNoteScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
-    Scaffold(modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection), topBar = {
-        TopAppBar(
-            title = { Text("Add note") },
-            modifier = Modifier
-                .windowInsetsPadding(WindowInsets.statusBars)
-                .padding(bottom = LifeHubTheme.spacing.stack.medium),
-            navigationIcon = {
-                IconButton(onClick = onClickBack) {
-                    Icon(
-                        Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "top bar arrow back"
-                    )
-                }
-            },
-            scrollBehavior = scrollBehavior
-        )
-    }) { paddingValues ->
+    Scaffold(
+        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.only(WindowInsetsSides.Top),
+        topBar = {
+            TopAppBar(
+                title = { Text("Add note") },
+                modifier = Modifier
+                    .padding(bottom = LifeHubTheme.spacing.stack.medium),
+                navigationIcon = {
+                    IconButton(onClick = onClickBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "top bar arrow back"
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior
+            )
+        }) { paddingValues ->
         AddNoteContent(
             uiState = uiState,
             modifier = Modifier
@@ -91,66 +92,63 @@ private fun AddNoteContent(
     onSetContent: (String) -> Unit,
     onClickAddNote: () -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
+
     var title by remember { mutableStateOf("") }
     var content by remember { mutableStateOf("") }
 
     Column(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(LifeHubTheme.spacing.inset.medium),
         verticalArrangement = Arrangement.spacedBy(LifeHubTheme.spacing.stack.medium)
     ) {
+        TextInput(
+            value = title,
+            inputTitle = "Title",
+            onValueChange = { input ->
+                title = input
+                onSetTitle(title)
+            },
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Sentences,
+                autoCorrectEnabled = true,
+                imeAction = ImeAction.Next
+            )
+        )
 
-        Card(
-            modifier = Modifier
+        TextInput(
+            value = content,
+            inputTitle = "Content",
+            singleLine = false,
+            maxLines = 100,
+            inputModifier = Modifier
                 .fillMaxWidth()
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(LifeHubTheme.spacing.inset.medium),
-                verticalArrangement = Arrangement.spacedBy(LifeHubTheme.spacing.stack.medium)
-            ) {
-                TextInput(
-                    value = title,
-                    inputTitle = "Title",
-                    onValueChange = { input ->
-                        title = input
-                        onSetTitle(title)
-                    },
-                    keyboardOptions = KeyboardOptions(
-                        capitalization = KeyboardCapitalization.Sentences,
-                        autoCorrectEnabled = true,
-                        imeAction = ImeAction.Next
-                    )
-                )
-
-                TextInput(
-                    value = content,
-                    inputTitle = "Content",
-                    singleLine = false,
-                    maxLines = 100,
-                    inputModifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(min = 300.dp)
-                        .clip(LifeHubTheme.shapes.medium),
-                    onValueChange = { input ->
-                        content = input
-                        onSetContent(input)
-                    },
-                    keyboardOptions = KeyboardOptions(
-                        capitalization = KeyboardCapitalization.Sentences,
-                        autoCorrectEnabled = true,
-                        imeAction = ImeAction.Done
-                    )
-                )
-
-                ButtonPrimary(
-                    onClick = onClickAddNote,
-                    enabled = uiState.isNoteFilled,
-                    modifier = Modifier.align(Alignment.End)
-                ) {
-                    Text(text = "Add note")
+                .heightIn(min = 300.dp)
+                .clip(LifeHubTheme.shapes.medium),
+            onValueChange = { input ->
+                content = input
+                onSetContent(input)
+            },
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Sentences,
+                autoCorrectEnabled = true,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    focusManager.clearFocus()
                 }
-            }
+            )
+        )
+
+        ButtonPrimary(
+            onClick = onClickAddNote,
+            enabled = uiState.isNoteFilled,
+            modifier = Modifier
+                .align(Alignment.End)
+        ) {
+            Text(text = "Add note")
         }
     }
 }

--- a/app/src/main/java/com/example/lifehub/ui/screens/notes/add/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/lifehub/ui/screens/notes/add/AddNoteScreen.kt
@@ -2,11 +2,15 @@ package com.example.lifehub.ui.screens.notes.add
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -17,6 +21,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,6 +30,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -32,31 +40,45 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.lifehub.theme.LifeHubTheme
 import com.example.lifehub.ui.components.ButtonPrimary
 import com.example.lifehub.ui.components.TextInput
-import com.example.lifehub.ui.components.UiStateScreenContainer
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddNoteScreen(
     viewModel: AddNoteViewModel = hiltViewModel(),
+    onAddNote: () -> Unit,
     onClickBack: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
-    Scaffold(topBar = {
-        TopAppBar(title = { Text("Add note") }, navigationIcon = {
-            IconButton(onClick = onClickBack) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "top bar arrow back")
-            }
-        })
+    Scaffold(modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection), topBar = {
+        TopAppBar(
+            title = { Text("Add note") },
+            modifier = Modifier
+                .windowInsetsPadding(WindowInsets.statusBars)
+                .padding(bottom = LifeHubTheme.spacing.stack.medium),
+            navigationIcon = {
+                IconButton(onClick = onClickBack) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "top bar arrow back"
+                    )
+                }
+            },
+            scrollBehavior = scrollBehavior
+        )
     }) { paddingValues ->
         AddNoteContent(
             uiState = uiState,
-            modifier = Modifier.padding(paddingValues),
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(paddingValues),
             onSetTitle = viewModel::setTitle,
             onSetContent = viewModel::setContent,
             onClickAddNote = {
                 viewModel.createNote()
-                onClickBack()
+                onAddNote()
             })
     }
 }
@@ -69,65 +91,64 @@ private fun AddNoteContent(
     onSetContent: (String) -> Unit,
     onClickAddNote: () -> Unit
 ) {
-    UiStateScreenContainer(
-        loading = false,
+    var title by remember { mutableStateOf("") }
+    var content by remember { mutableStateOf("") }
+
+    Column(
         modifier = modifier,
-        empty = false,
-        emptyContent = {},
-        onRefresh = {}
+        verticalArrangement = Arrangement.spacedBy(LifeHubTheme.spacing.stack.medium)
     ) {
-        var title by remember { mutableStateOf("") }
-        var content by remember { mutableStateOf("") }
 
-        Column(
+        Card(
             modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(LifeHubTheme.spacing.inset.medium),
-            verticalArrangement = Arrangement.spacedBy(LifeHubTheme.spacing.stack.medium)
+                .fillMaxWidth()
         ) {
-
-            Card(
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .padding(LifeHubTheme.spacing.inset.medium),
+                verticalArrangement = Arrangement.spacedBy(LifeHubTheme.spacing.stack.medium)
             ) {
-                Column(
-                    modifier = Modifier
+                TextInput(
+                    value = title,
+                    inputTitle = "Title",
+                    onValueChange = { input ->
+                        title = input
+                        onSetTitle(title)
+                    },
+                    keyboardOptions = KeyboardOptions(
+                        capitalization = KeyboardCapitalization.Sentences,
+                        autoCorrectEnabled = true,
+                        imeAction = ImeAction.Next
+                    )
+                )
+
+                TextInput(
+                    value = content,
+                    inputTitle = "Content",
+                    singleLine = false,
+                    maxLines = 100,
+                    inputModifier = Modifier
                         .fillMaxWidth()
-                        .padding(LifeHubTheme.spacing.inset.medium),
-                    verticalArrangement = Arrangement.spacedBy(LifeHubTheme.spacing.stack.medium)
+                        .heightIn(min = 300.dp)
+                        .clip(LifeHubTheme.shapes.medium),
+                    onValueChange = { input ->
+                        content = input
+                        onSetContent(input)
+                    },
+                    keyboardOptions = KeyboardOptions(
+                        capitalization = KeyboardCapitalization.Sentences,
+                        autoCorrectEnabled = true,
+                        imeAction = ImeAction.Done
+                    )
+                )
+
+                ButtonPrimary(
+                    onClick = onClickAddNote,
+                    enabled = uiState.isNoteFilled,
+                    modifier = Modifier.align(Alignment.End)
                 ) {
-                    TextInput(
-                        value = title,
-                        inputTitle = "Title",
-                        onValueChange = { input ->
-                            title = input
-                            onSetTitle(title)
-                        }
-                    )
-
-                    TextInput(
-                        value = content,
-                        inputTitle = "Content",
-                        singleLine = false,
-                        maxLines = 100,
-                        inputModifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 300.dp)
-                            .clip(LifeHubTheme.shapes.medium),
-                        onValueChange = { input ->
-                            content = input
-                            onSetContent(input)
-                        }
-                    )
-
-                    ButtonPrimary(
-                        onClick = onClickAddNote,
-                        enabled = uiState.isNoteFilled,
-                        modifier = Modifier.align(Alignment.End)
-                    ) {
-                        Text(text = "Add note")
-                    }
+                    Text(text = "Add note")
                 }
             }
         }
@@ -138,6 +159,6 @@ private fun AddNoteContent(
 @Composable
 private fun AddNotesScreenPreview() {
     LifeHubTheme {
-        AddNoteScreen(onClickBack = {})
+        AddNoteScreen(onAddNote = {}, onClickBack = {})
     }
 }

--- a/app/src/main/java/com/example/lifehub/ui/screens/notes/notedetails/NoteDetailsScreen.kt
+++ b/app/src/main/java/com/example/lifehub/ui/screens/notes/notedetails/NoteDetailsScreen.kt
@@ -34,7 +34,6 @@ import com.example.lifehub.theme.LifeHubTheme
 import com.example.lifehub.ui.components.ButtonPrimary
 import com.example.lifehub.ui.components.UiStateScreenContainer
 import kotlinx.coroutines.launch
-import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -124,11 +123,8 @@ private fun NoteDetailsContent(note: Note?, modifier: Modifier) {
                     verticalArrangement = Arrangement.spacedBy(LifeHubTheme.spacing.stack.medium)
                 ) {
                     Text(
-                        text = validNote.title.replaceFirstChar {
-                            if (it.isLowerCase()) it.titlecase(
-                                Locale.ROOT
-                            ) else it.toString()
-                        }, style = MaterialTheme.typography.headlineSmall,
+                        text = validNote.title,
+                        style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.SemiBold
                     )
                     Text(text = validNote.content, style = MaterialTheme.typography.bodyLarge)

--- a/app/src/main/java/com/example/lifehub/ui/screens/notes/notedetails/NoteDetailsScreen.kt
+++ b/app/src/main/java/com/example/lifehub/ui/screens/notes/notedetails/NoteDetailsScreen.kt
@@ -2,9 +2,14 @@ package com.example.lifehub.ui.screens.notes.notedetails
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
@@ -14,9 +19,11 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -25,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -42,20 +50,22 @@ fun NoteDetailsScreen(
     onDeleteNote: () -> Unit,
     onClickBack: () -> Unit
 ) {
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
     var showBottomSheet by remember { mutableStateOf(false) }
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    Scaffold(
+    Scaffold(modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.only(WindowInsetsSides.Top),
         topBar = {
             TopAppBar(
                 title = {
                     Text(
-                        text = "Note",
+                        text = uiState.item?.title ?: "Note",
                         style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Medium
+                        fontWeight = FontWeight.SemiBold
                     )
                 },
                 navigationIcon = {
@@ -76,13 +86,13 @@ fun NoteDetailsScreen(
                         )
                     }
                 },
+                scrollBehavior = scrollBehavior
             )
         }) { paddingValues ->
         NoteDetailsContent(
             note = uiState.item,
             modifier = Modifier
                 .padding(paddingValues)
-                .fillMaxSize()
         )
 
         if (showBottomSheet) {
@@ -111,26 +121,21 @@ private fun NoteDetailsContent(note: Note?, modifier: Modifier) {
         modifier = modifier,
         empty = false,
         emptyContent = {},
-        onRefresh = {}
+        onRefresh = null
     ) {
-
-        Column {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(LifeHubTheme.spacing.inset.medium)
+                .navigationBarsPadding(),
+            verticalArrangement = Arrangement.spacedBy(LifeHubTheme.spacing.stack.medium)
+        ) {
             note?.let { validNote ->
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(LifeHubTheme.spacing.inset.medium),
-                    verticalArrangement = Arrangement.spacedBy(LifeHubTheme.spacing.stack.medium)
-                ) {
-                    Text(
-                        text = validNote.title,
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.SemiBold
-                    )
-                    Text(text = validNote.content, style = MaterialTheme.typography.bodyLarge)
-                }
+                Text(text = validNote.content, style = MaterialTheme.typography.bodyLarge)
             }
         }
+
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">LifeHub</string>
     <string name="successfully_deleted_note_message">Note was deleted</string>
+    <string name="successfully_created_note_message">Note was created</string>
 </resources>


### PR DESCRIPTION
- Changes the background color from light gray to white.
- Updates the input field container color from `0XFFE1F5FE` to `0xFFEBF9FF`.
- Sets `windowSoftInputMode` to `adjustResize` in `AndroidManifest.xml`.
- Removes the `resultViewModel` from the parameters of `NoteDetailsScreen` in `NavGraph.kt`.
- Reorders the position of `android:name` and `android:allowBackup` in AndroidManifest.xml

- Adds `TopAppBarDefaults.enterAlwaysScrollBehavior` to `NotesScreen` and `AddNoteScreen` for better scrolling behavior.
- Adds `nestedScroll` modifier to `Scaffold` in `NotesScreen` and `AddNoteScreen` to enable scrolling.
- Updates `NoteScreenTopBar` to receive `TopAppBarScrollBehavior` for scrolling behavior.
- Adds `windowInsetsPadding` and padding to `TopAppBar` in `AddNoteScreen`.
- Adds `keyboardOptions` with `KeyboardCapitalization.Sentences`, `autoCorrectEnabled = true` and `ImeAction` to `TextInput` in `AddNoteScreen`.
- Adds `maxLines` and `overflow` to `Text` in `NoteItem`.
- Adds `isLoading` to `NotesContent` to properly handle empty states.
- Removes unnecessary locale handling from titles.
- Improves the general layout of the screens.

- Adds `scrollBehavior` to `NoteDetailsScreen` `TopAppBar`.
- Adds `verticalScroll` and `navigationBarsPadding` to `NoteDetailsContent`.
- Removes `fillMaxSize` from `NoteDetailsContent` modifier.
- Updates `NoteDetailsScreen` top app bar title to use the note title.
- Updates `HomeScreen` to use `ScaffoldDefaults.contentWindowInsets.only(WindowInsetsSides.Top)`
- Removes `WindowInsets.statusBars` from `AddNoteScreen` top bar.
- Adds `KeyboardActions` to the content text input in `AddNoteContent` to clear focus on `Done` action.
- Removes the card container from `AddNoteContent` and change it to `Column`.
- Updates `AddNoteScreen` to show snack bar message after successfully creating note.
- Updates Note Details Screen Top Bar to use SemiBold font weight.

- Adds `combinedClickable` to `NoteItem` for handling long clicks to trigger note deletion.
- Adds `DeleteNoteBottomSheet` for confirmation before deleting a note.
- Implements note deletion logic in `NotesViewModel` and `NotesScreen`.
- Updates the `NotesUiState` to show notes reversed by the time they were created.
- Refines UI by using `WindowInsetsSides` for `Scaffold` and `navigationBarsPadding` for `SmallFloatingActionButton`.
- Updates padding between note items to `small`.
- Updates `onRefresh` to `null` since is not needed.